### PR TITLE
using a more robust artifact finding mechanism

### DIFF
--- a/sagemaker-python-sdk/mxnet_gluon_embedding_server/mxnet_embedding_server.ipynb
+++ b/sagemaker-python-sdk/mxnet_gluon_embedding_server/mxnet_embedding_server.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Building an image embedding server with Gluon\n",
     "In this notebook, we use a pre-trained model to extract image embeddings.\n",
-    "* **Image embeddings** are dense, high-semantic, low-dimension vector representation of images learnt by neural networks. They can directly by learnt by a model, or obtained as a byproduct of a downstream task. In this demo, we use a pre-trained classifier from the gluon model zoo to obtain those embeddings:\n",
+    "* **Image embeddings** are dense, high-semantic, low-dimension vector representation of images learnt by neural networks. They can directly be learnt by a model, or obtained as a byproduct of a downstream task. In this demo, we use a pre-trained classifier from the gluon model zoo to obtain those embeddings:\n",
     " 1. We first import a model from the gluon model zoo locally on the notebook, that we then compress and send to S3\n",
     " 1. We then use the SageMaker MXNet Serving feature to deploy the embedding model to a real-time managed endpoint. It uses the model artifact that we previously loaded to S3.\n",
     " 1. We query the endpoint and visualize embeddings in a 2D scatter plot using PCA\n",
@@ -251,15 +251,12 @@
     "    :param: model_dir The directory where model files are stored.\n",
     "    :return: a model (in this case a Gluon network)\n",
     "    \n",
-    "    lil hack: we pass gluon model name as artifact name so that at serving\n",
-    "    we know which model to use\n",
+    "    assumes that the parameters artifact is {model_name}.params\n",
     "    \"\"\"\n",
-    "    filename = os.listdir(model_dir)[0]\n",
-    "    print('file found in model_dir: ' + filename)\n",
-    "    modelname = filename[:filename.find('.params')]\n",
+    "    modelname = os.environ['modelname']\n",
     "    net = models.get_model(name=modelname, pretrained=False, ctx=mx.cpu())\n",
-    "    net.load_parameters(os.path.join(model_dir, filename))\n",
-    "    logging.info('loaded parameters into model ' + filename)\n",
+    "    net.load_parameters(os.path.join(model_dir, modelname + '.params'))\n",
+    "    logging.info('loaded parameters into model ' + modelname)\n",
     "\n",
     "    return net\n",
     "\n",
@@ -347,6 +344,7 @@
     "    role=get_execution_role(),\n",
     "    py_version='py3',\n",
     "    entry_point='embedding_server.py',\n",
+    "    env={'modelname': modelname})  # we pass model name via an environment variable \n"
     "    framework_version='1.4')"
    ]
   },


### PR DESCRIPTION
using an environment variable to explicitly call model file by name instead of using `os.listdir()`